### PR TITLE
Fixed Background on custom Theme

### DIFF
--- a/PitFusion.html
+++ b/PitFusion.html
@@ -1,19 +1,13 @@
 <!DOCTYPE html>
 <!-- ============================================================
-     PITFUSION Created by Mike King on Team 88
-     ============================================================ -->
-
-<!-- ============================================================
      PITFUSION CONFIGURATION — EDIT KEYS HERE
      ============================================================ -->
 <script>
 // ── API Keys ─────────────────────────────────────────────────
-
 const NEXUS_KEY = 'YOUR_NEXUS_API_KEY';
 const TBA_KEY   = 'YOUR_TBA_API_KEY';
-
 // ── Version ──────────────────────────────────────────────────
-const VERSION   = 'V1.1.2';
+const VERSION   = 'V1.1.3';
 // ─────────────────────────────────────────────────────────────
 </script>
 <html lang="en">
@@ -123,7 +117,7 @@ document.addEventListener('DOMContentLoaded',()=>{
   --custom-bg-image: none;
   /* Washout overlay — 0.0 (none) to 1.0 (fully washed out). Dark themes
      typically use 0.5–0.8; light themes 0.1–0.4 */
-  --custom-bg-washout: 0.65;
+  --custom-bg-washout: 0.0;  /* 0 = no overlay when no image; increase when using a bg image */
   /* Washout overlay color — use black for dark themes, white for light */
   --custom-bg-washout-color: 0,0,0;
 }
@@ -142,26 +136,38 @@ body[data-theme="tj2"]{
   background-repeat: no-repeat;
   background-attachment: fixed;
 }
-/* Custom theme — optional background image with washout */
-body[data-theme="custom"][style*="--custom-bg-image"]::before,
-body[data-theme="custom"]::before{
-  content:'';
-  position:fixed;inset:0;
-  background:rgba(var(--custom-bg-washout-color),var(--custom-bg-washout));
-  pointer-events:none;
-  z-index:0;
-  display:var(--custom-before-display, none);
+/* Custom theme — background image baked in like TJ2 (no ::before, no has-bg) */
+/* When --custom-bg-image is set to a url(), it shows with the washout gradient on top */
+body[data-theme="custom"]{
+  background-color: var(--bg);
+  background-image:
+    linear-gradient(
+      rgba(var(--custom-bg-washout-color), var(--custom-bg-washout)),
+      rgba(var(--custom-bg-washout-color), var(--custom-bg-washout))
+    ),
+    var(--custom-bg-image);
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
 }
-body[data-theme="custom"].has-bg{
-  background-image:var(--custom-bg-image);
-  background-size:cover;
-  background-position:center;
-  background-repeat:no-repeat;
-  background-attachment:fixed;
+/* Custom theme — frosted glass panels when background image is active */
+/* Custom theme panels — glass effect only when bg image is active (body.custom-has-bg) */
+body.custom-has-bg[data-theme="custom"] .hdr,
+body.custom-has-bg[data-theme="custom"] .footer,
+body.custom-has-bg[data-theme="custom"] .col-l,
+body.custom-has-bg[data-theme="custom"] .sidebar,
+body.custom-has-bg[data-theme="custom"] .stream-bar,
+body.custom-has-bg[data-theme="custom"] .tab-bar,
+body.custom-has-bg[data-theme="custom"] .panel-m{
+  background:rgba(var(--custom-bg-washout-color, 0,0,0), 0.55);
+  backdrop-filter:blur(12px);
+  -webkit-backdrop-filter:blur(12px);
 }
-body[data-theme="custom"].has-bg::before{
-  display:block;
+body.custom-has-bg[data-theme="custom"] .tp{
+  background:rgba(var(--custom-bg-washout-color, 0,0,0), 0.55);
 }
+
 /* Setup page z-index handled by its own rule (10000) */
 #app{display:grid;grid-template-rows:var(--hdr-h) 1fr var(--ftr-h);width:100vw;height:100vh;overflow:hidden}
 
@@ -905,7 +911,7 @@ body.pit-xl .rt th{ font-size:var(--fs-pit) !important; }
 
     <div class="setup-field">
       <label class="setup-label" for="setup-team">Team Number</label>
-      <input class="setup-input" id="setup-team" type="number" placeholder="e.g. 254" min="1" max="99999" autocomplete="off">
+      <input class="setup-input" id="setup-team" type="number" placeholder="e.g. 88" min="1" max="99999" autocomplete="off">
     </div>
 
     <div class="setup-field">
@@ -1065,20 +1071,12 @@ function applyTheme(t){
   document.body.setAttribute('data-theme', t);
 }
 
-function applyCustomBg(){
-  // Read --custom-bg-image from the custom theme block and apply has-bg if set
-  const tmp = document.createElement('div');
-  tmp.setAttribute('data-theme','custom');
-  tmp.style.cssText = 'position:absolute;visibility:hidden';
-  document.body.appendChild(tmp);
-  const val = getComputedStyle(tmp).getPropertyValue('--custom-bg-image').trim();
-  document.body.remove ? null : null;
-  tmp.remove();
-  if(val && val !== 'none' && val !== ''){
-    document.body.classList.add('has-bg');
-  } else {
-    document.body.classList.remove('has-bg');
-  }
+
+
+function applyCustomHasBg(){
+  const val = getComputedStyle(document.documentElement)
+                .getPropertyValue('--custom-bg-image').trim();
+  document.body.classList.toggle('custom-has-bg', !!(val && val !== 'none' && val !== ''));
 }
 
 function selectTheme(t, el){
@@ -1090,7 +1088,7 @@ function selectTheme(t, el){
     const s = document.querySelector(`.theme-swatch[data-theme="${t}"]`);
     if(s) s.classList.add('active');
   }
-  if(t === 'custom') applyCustomBg();
+  if(t === 'custom') applyCustomHasBg();
 }
 
 // Apply saved theme immediately on load (before paint)
@@ -1101,7 +1099,7 @@ function selectTheme(t, el){
   document.addEventListener('DOMContentLoaded', ()=>{
     const s = document.querySelector(`.theme-swatch[data-theme="${saved}"]`);
     if(s){ document.querySelectorAll('.theme-swatch').forEach(x=>x.classList.remove('active')); s.classList.add('active'); }
-    if(saved === 'custom') applyCustomBg();
+    if(saved === 'custom') applyCustomHasBg();
   });
 })();
 
@@ -1385,30 +1383,57 @@ function rQ(){
     return false;
   };
   const myMxQ=mx.filter(m=>[...(m.redTeams||[]),...(m.blueTeams||[])].includes(C.team));
-  const myNext=nowQ?myMxQ.find(m=>!isPlayedQ(m)):null;
+  // When actively queuing, find next unplayed Nexus match.
+  // When on break (nowQ null), fall back to TBA data for next unplayed match.
+  let myNext = nowQ ? myMxQ.find(m=>!isPlayedQ(m)) : null;
+  if(!myNext && tbaMx){
+    // Build next match from TBA — find earliest unplayed match for our team
+    const tbaMyMx = tbaMx
+      .filter(m=>{
+        const r=(m.alliances?.red?.team_keys||[]).map(k=>k.replace('frc',''));
+        const bl=(m.alliances?.blue?.team_keys||[]).map(k=>k.replace('frc',''));
+        return r.includes(C.team)||bl.includes(C.team);
+      })
+      .filter(m=>m.actual_time==null)  // not yet played per TBA
+      .sort((a,b)=>(a.predicted_time||a.time||0)-(b.predicted_time||b.time||0));
+    if(tbaMyMx.length){
+      // Convert TBA match to Nexus-like shape for display
+      const tm=tbaMyMx[0];
+      const rk=(tm.alliances?.red?.team_keys||[]).map(k=>k.replace('frc',''));
+      const bk=(tm.alliances?.blue?.team_keys||[]).map(k=>k.replace('frc',''));
+      const lvl=tm.comp_level==='qm'?'Qual':tm.comp_level==='sf'?'Playoff':tm.comp_level==='f'?'Final':'Match';
+      myNext={
+        label:`${lvl} ${tm.match_number}`,
+        redTeams:rk, blueTeams:bk,
+        status:'', times:{estimatedQueueTime:tm.predicted_time?(tm.predicted_time-1800)*1000:null}
+      };
+    }
+  }
 
   // Expected queue time for myNext
   const myNextQt=myNext?.times?.estimatedQueueTime||myNext?.times?.actualQueueTime;
   const myNextTimeStr=myNextQt?ft(new Date(myNextQt)):null;
 
   let html='';
-  if(nowQ){
+  if(nowQ||myNext){
     const heading=myNext?e(myNext.label):'&mdash;';
     const subline=myNextTimeStr
       ?`<div style="font-family:var(--fd);font-size:var(--fs-lbl);font-weight:700;color:var(--text);margin-top:2px">Est. Queue: ${myNextTimeStr}</div>`
       :'';
-    html+=`<div class="sec-lbl" style="font-size:var(--fs-sm);margin-bottom:2px">Your Next Match</div><div class="now-q">${heading}</div>${subline}`;
+    const statusLbl=nowQ?'Your Next Match':'Your Next Match';
+    const breakBadge=!nowQ?`<div style="font-family:var(--fd);font-size:var(--fs-sm);font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--yellow);margin-bottom:4px">⏸ On Break</div>`:'';
+    html+=`${breakBadge}<div class="sec-lbl" style="font-size:var(--fs-sm);margin-bottom:2px">${statusLbl}</div><div class="now-q">${heading}</div>${subline}`;
   } else {
     html+=`<div class="not-q">Not queuing</div>`;
   }
 
   // Alliance grid — show alliances for team's next match
-  if(nowQ && myNext && (myNext.redTeams?.length || myNext.blueTeams?.length)){
+  if(myNext && (myNext.redTeams?.length || myNext.blueTeams?.length)){
     const r=myNext.redTeams||[],bl=myNext.blueTeams||[];
     html+=`<div class="a-row"><div class="a-blk bl"><div class="a-label">Blue</div>${bl.map(t=>`<div class="a-team${t===C.team?' me':''}">${e(t)}</div>`).join('')}</div><div class="vs">VS</div><div class="a-blk rd"><div class="a-label">Red</div>${r.map(t=>`<div class="a-team${t===C.team?' me':''}">${e(t)}</div>`).join('')}</div></div>`;
   }
 
-  // 3-column status strip: On Field | On Deck | Queuing
+  // 3-column status strip — only when actively queuing
   if(nowQ){
     html+=`<div class="ss">
       <div class="sc"><div class="sc-l">On Field</div><div class="sc-v${onFieldMatch?' on':''}">${onFieldMatch?e(onFieldMatch.label):'&mdash;'}</div></div>
@@ -1834,7 +1859,23 @@ function updateBumperBox() {
     };
 
     const myMx   = mx.filter(m=>[...(m.redTeams||[]),...(m.blueTeams||[])].includes(myT));
-    const myNext = nowQ ? myMx.find(m=>!isPlayed(m)) : null;
+    let myNext = nowQ ? myMx.find(m=>!isPlayed(m)) : null;
+    // During break, fall back to TBA for next unplayed match
+    if(!myNext && tbaMx){
+      const tbaNext = tbaMx
+        .filter(m=>m.actual_time==null)
+        .filter(m=>{
+          const r=(m.alliances?.red?.team_keys||[]).map(k=>k.replace('frc',''));
+          const bl=(m.alliances?.blue?.team_keys||[]).map(k=>k.replace('frc',''));
+          return r.includes(myT)||bl.includes(myT);
+        })
+        .sort((a,b)=>(a.predicted_time||a.time||0)-(b.predicted_time||b.time||0))[0];
+      if(tbaNext){
+        const rk=(tbaNext.alliances?.red?.team_keys||[]).map(k=>k.replace('frc',''));
+        const bk=(tbaNext.alliances?.blue?.team_keys||[]).map(k=>k.replace('frc',''));
+        myNext={label:'',redTeams:rk,blueTeams:bk};
+      }
+    }
 
     // Bumper color — only when actively queuing and we have a next match
     if (!nowQ || !myNext) {


### PR DESCRIPTION
1. No more unwanted dimming — The default --custom-bg-washout is now 0.0 (fully transparent), so when there's no background image the overlay is invisible and nothing gets dimmed.
2. Background image now works — Instead of the broken has-bg class approach, the background is now baked directly into body[data-theme="custom"] as a CSS gradient+image stack — same technique that works reliably for TJ². When --custom-bg-image is none, background-image: gradient, none renders as just the --bg color with no side effects.
3. Glass panels only when image is active — A new custom-has-bg body class is toggled by JS after reading the resolved CSS variable from document.documentElement. The frosted glass panel effect only applies when that class is present, so panels stay normal when there's no background image.
For your 451Drive.jpeg, set --custom-bg-image: url('451Drive.jpeg') and bump --custom-bg-washout to around 0.5–0.65 for readability.

Fixes #2 